### PR TITLE
feat: Implement advanced list formatting plugin

### DIFF
--- a/list-formatter.ts
+++ b/list-formatter.ts
@@ -1,0 +1,92 @@
+// Helper for Roman numerals (simple version)
+const ROMAN_NUMERALS_UPPER = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI', 'XVII', 'XVIII', 'XIX', 'XX'];
+const ROMAN_NUMERALS_LOWER = ROMAN_NUMERALS_UPPER.map(n => n.toLowerCase());
+
+// Regex to remove existing common list prefixes
+// Explanation:
+// ^(\s*[-*+]\s+)                                - Matches common bullet points like -, *, + with surrounding spaces
+// | (^\s*\d+\.\s+)                              - Matches numbered lists like 1., 2. with surrounding spaces
+// | (^\s*[a-zA-Z][.)]\s+)                       - Matches alphabetical lists like a., a), B., B) with surrounding spaces
+// | (^\s*[ivxlcdmIVXLCDM]+\.\s+)                - Matches Roman numeral lists like i., I. with surrounding spaces
+// The (.*)$ part is to capture the rest of the line after the prefix.
+const PREFIX_REGEX = /^(\s*[-*+]\s+|^\s*\d+\.\s+|^\s*[a-zA-Z][.)]\s+|^\s*[ivxlcdmIVXLCDM]+\.\s+)(.*)$/;
+
+function processLine(line: string, newPrefix: string): string {
+    if (line.trim() === '') {
+        return line; // Preserve empty or whitespace-only lines
+    }
+
+    const leadingWhitespaceMatch = line.match(/^(\s*)/);
+    const indentation = leadingWhitespaceMatch ? leadingWhitespaceMatch[0] : '';
+    const content = line.substring(indentation.length);
+
+    const prefixMatch = content.match(PREFIX_REGEX);
+    if (prefixMatch) {
+        // If an existing list prefix is found, replace it with the new one
+        // prefixMatch[1] is the old prefix, prefixMatch[2] is the actual content after old prefix
+        return `${indentation}${newPrefix}${prefixMatch[2]}`;
+    } else {
+        // Otherwise, just prepend the new prefix to the (trimmed) content
+        return `${indentation}${newPrefix}${content}`;
+    }
+}
+
+export function formatBulletList(text: string): string {
+    const lines = text.split('\n');
+    const processedLines = lines.map(line => {
+        if (line.trim() === '') return line;
+        return processLine(line, '- ');
+    });
+    return processedLines.join('\n');
+}
+
+export function formatNumberedList(text: string): string {
+    const lines = text.split('\n');
+    let counter = 1;
+    const processedLines = lines.map(line => {
+        if (line.trim() === '') return line;
+        const prefix = `${counter}. `;
+        counter++;
+        return processLine(line, prefix);
+    });
+    return processedLines.join('\n');
+}
+
+export function formatAlphabeticalList(text: string, lower: boolean = true): string {
+    const lines = text.split('\n');
+    let charCode = lower ? 'a'.charCodeAt(0) : 'A'.charCodeAt(0);
+    const processedLines = lines.map(line => {
+        if (line.trim() === '') return line;
+        const prefix = `${String.fromCharCode(charCode)}. `;
+        charCode++;
+        // Basic handling for running out of letters (cycles back to 'a'/'A')
+        if (lower && charCode > 'z'.charCodeAt(0)) charCode = 'a'.charCodeAt(0);
+        if (!lower && charCode > 'Z'.charCodeAt(0)) charCode = 'A'.charCodeAt(0);
+        return processLine(line, prefix);
+    });
+    return processedLines.join('\n');
+}
+
+export function formatRomanList(text: string, lower: boolean = true): string {
+    const lines = text.split('\n');
+    let counter = 0;
+    const numerals = lower ? ROMAN_NUMERALS_LOWER : ROMAN_NUMERALS_UPPER;
+    const processedLines = lines.map(line => {
+        if (line.trim() === '') return line;
+        // Use modulo to cycle through numerals if more items than defined
+        const numeral = numerals[counter % numerals.length];
+        const prefix = `${numeral}. `;
+        counter++;
+        return processLine(line, prefix);
+    });
+    return processedLines.join('\n');
+}
+
+export function formatCheckboxList(text: string): string {
+    const lines = text.split('\n');
+    const processedLines = lines.map(line => {
+        if (line.trim() === '') return line;
+        return processLine(line, '- [ ] ');
+    });
+    return processedLines.join('\n');
+}

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,26 @@
 import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { formatBulletList, formatNumberedList, formatAlphabeticalList, formatRomanList, formatCheckboxList } from './list-formatter';
 
 // Remember to rename these classes and interfaces!
 
+interface AdvancedListSettings {
+	defaultStyle: string;
+	enabledStyles: string[];
+}
+
+const DEFAULT_ADVANCED_LIST_SETTINGS: AdvancedListSettings = {
+	defaultStyle: 'bullet',
+	enabledStyles: ['bullet', 'numbered', 'alphabetical', 'alphabeticalUpper', 'roman', 'romanUpper', 'checkbox']
+}
+
 interface MyPluginSettings {
 	mySetting: string;
+	advancedListSettings: AdvancedListSettings;
 }
 
 const DEFAULT_SETTINGS: MyPluginSettings = {
-	mySetting: 'default'
+	mySetting: 'default',
+	advancedListSettings: DEFAULT_ADVANCED_LIST_SETTINGS
 }
 
 export default class MyPlugin extends Plugin {
@@ -65,8 +78,47 @@ export default class MyPlugin extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'apply-list-style',
+			name: 'Apply list style',
+			editorCallback: (editor: Editor, view: MarkdownView) => {
+				const selection = editor.getSelection();
+				new ListStyleModal(this.app, this.settings.advancedListSettings, (style) => {
+					let formattedText = '';
+					switch (style) {
+						case 'bullet':
+							formattedText = formatBulletList(selection);
+							break;
+						case 'numbered':
+							formattedText = formatNumberedList(selection);
+							break;
+						case 'alphabetical':
+							formattedText = formatAlphabeticalList(selection, true); // lower
+							break;
+						case 'alphabeticalUpper':
+							formattedText = formatAlphabeticalList(selection, false); // UPPER
+							break;
+						case 'roman':
+							formattedText = formatRomanList(selection, true); // lower
+							break;
+						case 'romanUpper':
+							formattedText = formatRomanList(selection, false); // UPPER
+							break;
+						case 'checkbox':
+							formattedText = formatCheckboxList(selection);
+							break;
+						default:
+							console.error('Unknown list style:', style);
+							new Notice('Unknown list style selected.');
+							return; 
+					}
+					editor.replaceSelection(formattedText);
+				}).open();
+			}
+		});
+
 		// This adds a settings tab so the user can configure various aspects of the plugin
-		this.addSettingTab(new SampleSettingTab(this.app, this));
+		this.addSettingTab(new AdvancedListSettingTab(this.app, this));
 
 		// If the plugin hooks up any global DOM events (on parts of the app that doesn't belong to this plugin)
 		// Using this function will automatically remove the event listener when this plugin is disabled.
@@ -107,7 +159,51 @@ class SampleModal extends Modal {
 	}
 }
 
-class SampleSettingTab extends PluginSettingTab {
+const ALL_POSSIBLE_STYLES: Record<string, string> = {
+	'bullet': 'Bullet List (- item)',
+	'numbered': 'Numbered List (1. item)',
+	'alphabetical': 'Alphabetical List (a. item)',
+	'alphabeticalUpper': 'Alphabetical List (A. item)',
+	'roman': 'Roman Numeral List (i. item)',
+	'romanUpper': 'Roman Numeral List (I. item)',
+	'checkbox': 'Checkbox List (- [ ] item)'
+};
+
+class ListStyleModal extends Modal {
+	pluginSettings: AdvancedListSettings;
+	callback: (style: string) => void;
+
+	constructor(app: App, pluginSettings: AdvancedListSettings, callback: (style: string) => void) {
+		super(app);
+		this.pluginSettings = pluginSettings;
+		this.callback = callback;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.createEl('h2', { text: 'Choose List Format' });
+
+		this.pluginSettings.enabledStyles.forEach(styleId => {
+			if (ALL_POSSIBLE_STYLES[styleId]) { // Ensure styleId is valid
+				const button = contentEl.createEl('button', { 
+					text: ALL_POSSIBLE_STYLES[styleId],
+					cls: 'list-style-modal-button' 
+				});
+				button.addEventListener('click', () => {
+					this.callback(styleId);
+					this.close();
+				});
+			}
+		});
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+}
+
+class AdvancedListSettingTab extends PluginSettingTab {
 	plugin: MyPlugin;
 
 	constructor(app: App, plugin: MyPlugin) {
@@ -116,19 +212,71 @@ class SampleSettingTab extends PluginSettingTab {
 	}
 
 	display(): void {
-		const {containerEl} = this;
-
+		const { containerEl } = this;
 		containerEl.empty();
 
 		new Setting(containerEl)
-			.setName('Setting #1')
-			.setDesc('It\'s a secret')
-			.addText(text => text
-				.setPlaceholder('Enter your secret')
-				.setValue(this.plugin.settings.mySetting)
-				.onChange(async (value) => {
-					this.plugin.settings.mySetting = value;
+			.setName('Default list style')
+			.setDesc('Choose your default list style.')
+			.addDropdown(dropdown => {
+				// Clear existing options to prevent duplication on refresh
+				dropdown.selectEl.empty(); 
+				
+				// Add currently selected default style first to ensure it's always in the list
+				const currentDefault = this.plugin.settings.advancedListSettings.defaultStyle;
+				if (ALL_POSSIBLE_STYLES[currentDefault] && this.plugin.settings.advancedListSettings.enabledStyles.includes(currentDefault)) {
+					dropdown.addOption(currentDefault, ALL_POSSIBLE_STYLES[currentDefault]);
+				} else if (this.plugin.settings.advancedListSettings.enabledStyles.length > 0) {
+					// If current default is somehow invalid or not enabled, pick the first enabled one
+					const firstEnabled = this.plugin.settings.advancedListSettings.enabledStyles[0];
+					this.plugin.settings.advancedListSettings.defaultStyle = firstEnabled; // Correct the setting
+					dropdown.addOption(firstEnabled, ALL_POSSIBLE_STYLES[firstEnabled] || firstEnabled);
+				} else {
+					// Fallback if no styles are enabled (should not happen with default settings)
+					dropdown.addOption('bullet', ALL_POSSIBLE_STYLES['bullet']);
+          this.plugin.settings.advancedListSettings.defaultStyle = 'bullet';
+				}
+				
+				this.plugin.settings.advancedListSettings.enabledStyles.forEach(styleId => {
+					if (styleId !== this.plugin.settings.advancedListSettings.defaultStyle && ALL_POSSIBLE_STYLES[styleId]) {
+						dropdown.addOption(styleId, ALL_POSSIBLE_STYLES[styleId]);
+					}
+				});
+				dropdown.setValue(this.plugin.settings.advancedListSettings.defaultStyle);
+				dropdown.onChange(async (value) => {
+					this.plugin.settings.advancedListSettings.defaultStyle = value;
 					await this.plugin.saveSettings();
-				}));
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Enabled list styles')
+			.setDesc('Choose which list styles are available in the formatting modal.');
+
+		for (const styleId in ALL_POSSIBLE_STYLES) {
+			const label = ALL_POSSIBLE_STYLES[styleId];
+			new Setting(containerEl)
+				.setName(label) // Use the descriptive label for the setting name
+				.addToggle(toggle => toggle
+					.setValue(this.plugin.settings.advancedListSettings.enabledStyles.includes(styleId))
+					.onChange(async (value) => {
+						const { enabledStyles } = this.plugin.settings.advancedListSettings;
+						if (value) {
+							if (!enabledStyles.includes(styleId)) {
+								enabledStyles.push(styleId);
+							}
+						} else {
+							this.plugin.settings.advancedListSettings.enabledStyles = enabledStyles.filter(s => s !== styleId);
+						}
+						
+						// Ensure defaultStyle is still valid and enabled
+						if (!this.plugin.settings.advancedListSettings.enabledStyles.includes(this.plugin.settings.advancedListSettings.defaultStyle)) {
+							this.plugin.settings.advancedListSettings.defaultStyle = this.plugin.settings.advancedListSettings.enabledStyles[0] || 'bullet';
+						}
+						await this.plugin.saveSettings();
+						// Refresh the display to update the dropdown for default list style
+						this.display();
+					}));
+		}
 	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-	"id": "sample-plugin",
-	"name": "Sample Plugin",
+	"id": "advanced-lists-plugin",
+	"name": "Advanced Lists",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "Demonstrates some of the capabilities of the Obsidian API.",
+	"description": "Enhances Obsidian's list functionality with additional list types and formatting options.",
 	"author": "Obsidian",
 	"authorUrl": "https://obsidian.md",
 	"fundingUrl": "https://obsidian.md/pricing",


### PR DESCRIPTION
This commit introduces an Obsidian plugin that enhances list creation capabilities beyond the default Markdown offerings.

Features:
- Multiple List Styles: You can convert selected text into various list formats including:
    - Bullet (`- item`)
    - Numbered (`1. item`)
    - Alphabetical (lower: `a. item`, upper: `A. item`)
    - Roman Numerals (lower: `i. item`, upper: `I. item`)
    - Checkbox (`- [ ] item`)
- Interactive Style Selection: A modal dialog allows you to choose your desired list format when the "Apply list style" command is triggered.
- Customizable Settings:
    - You can set a default list style.
    - You can enable/disable specific list styles from appearing in the selection modal.
- Intelligent Formatting:
    - Preserves indentation of list items.
    - Correctly replaces existing Markdown list markers.
    - Handles empty lines within selections appropriately.
- UI:
    - Settings tab for plugin configuration.
    - Basic styling for the list selection modal.

The implementation includes:
- `main.ts`: Core plugin logic, settings management, command registration, and UI classes (`ListStyleModal`, `AdvancedListSettingTab`).
- `list-formatter.ts`: Contains functions for transforming text into different list formats.
- `styles.css`: Basic styling for the modal.
- `manifest.json`: Updated plugin metadata.